### PR TITLE
Problem: (CRO-409) Clicking "Add wallet" redirects to empty page

### DIFF
--- a/src/app/components/wallet-list/wallet-list.component.ts
+++ b/src/app/components/wallet-list/wallet-list.component.ts
@@ -45,6 +45,8 @@ export class WalletListComponent implements OnInit {
       this.walletService.selectWalletById(walletId);
       this.walletService.setDecryptedFlag(false);
     }
+
+    return false;
   }
 
   closeModal() {


### PR DESCRIPTION
Solution: Added `return` to hint Angular not to redirect away from the single page app.