### PR TITLE
Problem:(cro-1607)  incorrect send viewkey storing in sample wallet c…

### DIFF
--- a/src/app/components/deposit-funds-form/deposit-funds-form.component.ts
+++ b/src/app/components/deposit-funds-form/deposit-funds-form.component.ts
@@ -99,10 +99,6 @@ export class DepositFundsFormComponent implements OnInit {
   }
 
   confirm(): void {
-    this.walletService.sendViewkey = this.viewKey;
-    this.walletService.sendToAddressString = this.toAddress;
-    this.walletService.sendAmount = this.amountValue;
-    this.walletService.saveToLocal();
     this.status = Status.CONFIRMING;
   }
 

--- a/src/app/components/withdraw-funds-form/withdraw-funds-form.component.ts
+++ b/src/app/components/withdraw-funds-form/withdraw-funds-form.component.ts
@@ -106,10 +106,6 @@ export class WithdrawFundsFormComponent implements OnInit {
   }
 
   confirm(): void {
-    this.walletService.sendViewkey = this.viewKey;
-    this.walletService.sendToAddressString = this.toAddress;
-
-    this.walletService.saveToLocal();
     this.status = Status.CONFIRMING;
   }
 


### PR DESCRIPTION
sample wallet client stores send-viewkey to local storage for the convenince.

but in deposit, withdraw, 
it stored send-viewkey with other viewkey which is not used for sending amount.

so this pr removes "send-viewkey save" in deposit, withdraw `confirm` function.
it's only stored in sending amount.
