### PR TITLE
Problem: (cro-1615) outdated staking_state in sample wallet client fix #64

### DIFF
--- a/src/app/components/deposit-funds-form/deposit-funds-form.component.ts
+++ b/src/app/components/deposit-funds-form/deposit-funds-form.component.ts
@@ -68,9 +68,10 @@ export class DepositFundsFormComponent implements OnInit {
   }
 
   async fetchStakingAccount() {
-    var data = await this.walletService
-      .checkStakingStake(this.toAddress)
-      .toPromise();
+    var data = await this.walletService.checkStakingStake(
+      this.walletId,
+      this.toAddress
+    );
     var result = data["result"];
     if (result) {
       var bonded = result["bonded"];

--- a/src/app/components/unbond-funds-form/unbond-funds-form.component.ts
+++ b/src/app/components/unbond-funds-form/unbond-funds-form.component.ts
@@ -69,9 +69,10 @@ export class UnbondFundsFormComponent implements OnInit {
   }
 
   async fetchStakingAccount() {
-    var data = await this.walletService
-      .checkStakingStake(this.fromAddress)
-      .toPromise();
+    var data = await this.walletService.checkStakingStake(
+      this.walletId,
+      this.fromAddress
+    );
     var result = data["result"];
     if (result) {
       var bonded = result["bonded"];

--- a/src/app/components/withdraw-funds-form/withdraw-funds-form.component.ts
+++ b/src/app/components/withdraw-funds-form/withdraw-funds-form.component.ts
@@ -74,9 +74,10 @@ export class WithdrawFundsFormComponent implements OnInit {
   }
 
   async fetchStakingAccount() {
-    var data = await this.walletService
-      .checkStakingStake(this.fromAddress)
-      .toPromise();
+    var data = await this.walletService.checkStakingStake(
+      this.walletId,
+      this.fromAddress
+    );
     var result = data["result"];
     if (result) {
       var bonded = result["bonded"];

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -9,6 +9,7 @@ import { HttpClient } from "@angular/common/http";
 import * as _ from "lodash";
 
 import config from "../config";
+import { resolve } from "url";
 
 // to await BehaviourSubject
 async function convertToPromise<T>(subject: BehaviorSubject<T>): Promise<T> {
@@ -323,13 +324,30 @@ export class WalletService {
     });
   }
 
-  checkStakingStake(stakingAddress: string): Observable<string> {
-    return this.http.post<string>(this.coreUrl, {
-      jsonrpc: "2.0",
-      id: "jsonrpc",
-      method: "staking_state",
-      params: [stakingAddress],
-    });
+  async checkStakingStake(walletname, stakingAddress: string): Promise<string> {
+    var first_result = await this.http
+      .post<string>(this.coreUrl, {
+        jsonrpc: "2.0",
+        id: "jsonrpc",
+        method: "staking_state",
+        params: [walletname, stakingAddress],
+      })
+      .toPromise();
+    if (first_result["result"]) {
+      return new Promise((resolve) => {
+        resolve(first_result);
+      });
+    }
+
+    // try with previous version
+    return this.http
+      .post<string>(this.coreUrl, {
+        jsonrpc: "2.0",
+        id: "jsonrpc",
+        method: "staking_state",
+        params: [stakingAddress],
+      })
+      .toPromise();
   }
 
   checkWalletAddress(


### PR DESCRIPTION
## why
because `staking_state` protocol changed
additional wallet name should be provided   
to support v0.5, if first attempt fails, try again with v0.5 api


## what modified

### old 
staking address

### new
wallet name
staking address

support both of them